### PR TITLE
Support of Netgen 6.2.2004 or higher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,29 +140,33 @@ if(ENABLE_NETGEN)
     include_directories(${NETGEN_INCLUDE_DIR}/include)
     include_directories(${NETGEN_INCLUDE_DIR}/stlgeom)
 
-    # Set NETGEN_VERSION
-    file(STRINGS ${NETGEN_INCLUDE_DIR}/mydefs.hpp NETGEN_VERSION
-        REGEX "#define PACKAGE_VERSION.*"
-        )
+    if(NOT NETGEN_VERSION_MAJOR)
+        # Set NETGEN_VERSION
+        file(STRINGS ${NETGEN_INCLUDE_DIR}/mydefs.hpp NETGEN_VERSION
+            REGEX "#define PACKAGE_VERSION.*"
+            )
 
-    if(NETGEN_VERSION)
-        string(REGEX MATCHALL "[0-9]+" NETGEN_VERSION ${NETGEN_VERSION})
-        list(LENGTH NETGEN_VERSION NETGEN_VERSION_COUNT)
-        list(GET NETGEN_VERSION 0 NETGEN_VERSION_MAJOR)
-        if(NETGEN_VERSION_COUNT GREATER 1)
-            list(GET NETGEN_VERSION 1 NETGEN_VERSION_MINOR)
+        if(NETGEN_VERSION)
+            string(REGEX MATCHALL "[0-9]+" NETGEN_VERSION ${NETGEN_VERSION})
+            list(LENGTH NETGEN_VERSION NETGEN_VERSION_COUNT)
+            list(GET NETGEN_VERSION 0 NETGEN_VERSION_MAJOR)
+            if(NETGEN_VERSION_COUNT GREATER 1)
+                list(GET NETGEN_VERSION 1 NETGEN_VERSION_MINOR)
+            else()
+                set(NETGEN_VERSION_MINOR 0)
+            endif()
         else()
-            set(NETGEN_VERSION_MINOR 0)
+            # Assume version 6.2.
+            message(STATUS "WARNING: Assuming Netgen 6.2.")
+            set(NETGEN_VERSION_MAJOR 6)
+            set(NETGEN_VERSION_MINOR 2)
         endif()
-    else()
-        # Assume version 6.2.
-        message(STATUS "WARNING: Assuming Netgen 6.2.")
-        set(NETGEN_VERSION_MAJOR 6)
-        set(NETGEN_VERSION_MINOR 2)
+        set(NETGEN_VERSION_PATCH 0)
     endif()
 
-    MATH(EXPR NETGEN_VERSION "(${NETGEN_VERSION_MAJOR} << 16) + (${NETGEN_VERSION_MINOR} << 8)")
-    message(STATUS "Using Netgen version ${NETGEN_VERSION_MAJOR}.${NETGEN_VERSION_MINOR}, calculated: ${NETGEN_VERSION}")
+    MATH(EXPR NETGEN_VERSION "(${NETGEN_VERSION_MAJOR} << 16) + (${NETGEN_VERSION_MINOR} << 8) + (${NETGEN_VERSION_PATCH})")
+    MATH(EXPR NETGEN_VERSION_62_2004 "(6 << 16) + (2 << 8) + (2004)")
+    message(STATUS "Using Netgen version ${NETGEN_VERSION_MAJOR}.${NETGEN_VERSION_MINOR}.${NETGEN_VERSION_PATCH}, calculated: ${NETGEN_VERSION}")
 
 endif()
 
@@ -304,14 +308,18 @@ if(ENABLE_NETGEN)
     file(GLOB NETGENPlugin_SRC src/NETGENPlugin/*.cxx)
     add_library(NETGENPlugin ${NETGENPlugin_SRC})
     if (NETGEN_LIBRARY)
-        target_link_libraries(NETGENPlugin StdMeshers TKIGES TKXDEIGES ${NETGEN_LIBRARY})
+        target_link_libraries(NETGENPlugin StdMeshers TKIGES TKXDEIGES TKLCAF ${NETGEN_LIBRARY})
     else (NETGEN_LIBRARY)
-        target_link_libraries(NETGENPlugin StdMeshers nglib)
+        target_link_libraries(NETGENPlugin StdMeshers TKIGES TKXDEIGES TKLCAF nglib)
     endif (NETGEN_LIBRARY)
     if(WIN32)
         set_target_properties(NETGENPlugin PROPERTIES COMPILE_FLAGS "-DNETGENPLUGIN_EXPORTS -DNO_PARALLEL_THREADS -DOCCGEOMETRY -DNETGEN_VERSION=${NETGEN_VERSION}")
     else()
         set_target_properties(NETGENPlugin PROPERTIES COMPILE_FLAGS "${NETGEN_CXX_FLAGS} -DNETGEN_VERSION=${NETGEN_VERSION}")
+    endif()
+    if (NOT NETGEN_VERSION LESS NETGEN_VERSION_62_2004) # Version >= 6.2.2004
+        set_target_properties(NETGENPlugin PROPERTIES CXX_STANDARD_REQUIRED ON)
+        set_target_properties(NETGENPlugin PROPERTIES CXX_STANDARD 17) # Standard std=c++1y could work aswell
     endif()
 endif()
 

--- a/inc/NETGENPlugin_Mesher.hxx
+++ b/inc/NETGENPlugin_Mesher.hxx
@@ -36,7 +36,7 @@
 #include <SMESH_Algo.hxx>
 #include <SMESH_ProxyMesh.hxx>
 
-#define NETGEN_VERSION_STRING(a,b) (a << 16) + (b << 8)
+#define NETGEN_VERSION_STRING(a,b,c) (a << 16) + (b << 8) + (c)
 
 #include <TopTools_IndexedMapOfShape.hxx>
 
@@ -85,7 +85,7 @@ struct NETGENPlugin_ngMeshInfo
 struct NETGENPLUGIN_EXPORT NETGENPlugin_NetgenLibWrapper
 {
   bool             _isComputeOk;
-#if NETGEN_VERSION < NETGEN_VERSION_STRING(6,0)
+#if NETGEN_VERSION < NETGEN_VERSION_STRING(6,0,0)
   nglib::Ng_Mesh * _ngMesh;
 #else
   std::shared_ptr<nglib::Ng_Mesh> _ngMesh;
@@ -207,7 +207,7 @@ class NETGENPLUGIN_EXPORT NETGENPlugin_Mesher
   bool                 _optimize;
   int                  _fineness;
   bool                 _isViscousLayers2D;
-#if NETGEN_VERSION < NETGEN_VERSION_STRING(6,0)
+#if NETGEN_VERSION < NETGEN_VERSION_STRING(6,0,0)
   netgen::Mesh*        _ngMesh;
 #else
   std::shared_ptr<netgen::Mesh> _ngMesh;

--- a/src/NETGENPlugin/NETGENPlugin_NETGEN_3D.cxx
+++ b/src/NETGENPlugin/NETGENPlugin_NETGEN_3D.cxx
@@ -71,16 +71,16 @@
 #define OCCGEOMETRY
 #endif
 #include <occgeom.hpp>
-#include <ngexception.hpp>
+//#include <ngexception.hpp>
 namespace nglib {
 #include <nglib.h>
 }
 namespace netgen {
-#if NETGEN_VERSION >= NETGEN_VERSION_STRING(6,2)
+#if NETGEN_VERSION >= NETGEN_VERSION_STRING(6,2,0)
 	DLL_HEADER extern int OCCGenerateMesh(OCCGeometry&, shared_ptr<Mesh>&, MeshingParameters&);
-#elif NETGEN_VERSION >= NETGEN_VERSION_STRING(6,0)
+#elif NETGEN_VERSION >= NETGEN_VERSION_STRING(6,0,0)
 	DLL_HEADER extern int OCCGenerateMesh(OCCGeometry&, shared_ptr<Mesh>&, MeshingParameters&, int, int);
-#elif NETGEN_VERSION >= NETGEN_VERSION_STRING(5,0)
+#elif NETGEN_VERSION >= NETGEN_VERSION_STRING(5,0,0)
 	DLL_HEADER extern int OCCGenerateMesh(OCCGeometry&, Mesh*&, MeshingParameters&, int, int);
 #else
 	DLL_HEADER extern int OCCGenerateMesh(OCCGeometry&, Mesh*&, int, int, char*);
@@ -209,7 +209,7 @@ bool NETGENPlugin_NETGEN_3D::Compute(SMESH_Mesh&         aMesh,
   int Netgen_triangle[3];
 
   NETGENPlugin_NetgenLibWrapper ngLib;
-#if NETGEN_VERSION < NETGEN_VERSION_STRING(6,0)
+#if NETGEN_VERSION < NETGEN_VERSION_STRING(6,0,0)
   Ng_Mesh * Netgen_mesh = ngLib._ngMesh;
 #else
   Ng_Mesh * Netgen_mesh = ngLib._ngMesh.get();
@@ -433,11 +433,11 @@ bool NETGENPlugin_NETGEN_3D::compute(SMESH_Mesh&                     aMesh,
   netgen::Mesh* ngMesh = (netgen::Mesh*)Netgen_mesh;
   int Netgen_NbOfNodes = Ng_GetNP(Netgen_mesh);
 
-#if NETGEN_VERSION < NETGEN_VERSION_STRING(5,0)
+#if NETGEN_VERSION < NETGEN_VERSION_STRING(5,0,0)
   char *optstr = 0;
 #endif
 
-#if NETGEN_VERSION < NETGEN_VERSION_STRING(6,2)
+#if NETGEN_VERSION < NETGEN_VERSION_STRING(6,2,0)
   int startWith = netgen::MESHCONST_MESHVOLUME;
   int endWith = netgen::MESHCONST_OPTVOLUME;
 #else
@@ -471,7 +471,7 @@ bool NETGENPlugin_NETGEN_3D::compute(SMESH_Mesh&                     aMesh,
       }
     }
     if ( !_hypParameters->GetOptimize() )
-#if NETGEN_VERSION < NETGEN_VERSION_STRING(6,2)
+#if NETGEN_VERSION < NETGEN_VERSION_STRING(6,2,0)
 		endWith = netgen::MESHCONST_MESHVOLUME;
 #else
 		netgen::mparam.perfstepsend = netgen::MESHCONST_MESHVOLUME;
@@ -502,14 +502,14 @@ bool NETGENPlugin_NETGEN_3D::compute(SMESH_Mesh&                     aMesh,
   try
   {
     OCC_CATCH_SIGNALS;
-#if NETGEN_VERSION >= NETGEN_VERSION_STRING(6,0)
+#if NETGEN_VERSION >= NETGEN_VERSION_STRING(6,0,0)
 	std::shared_ptr<netgen::Mesh> mesh_ptr(ngMesh, [](netgen::Mesh*) {});
-#if NETGEN_VERSION >= NETGEN_VERSION_STRING(6,2)
+#if NETGEN_VERSION >= NETGEN_VERSION_STRING(6,2,0)
 	err = netgen::OCCGenerateMesh(occgeo, mesh_ptr, netgen::mparam);
 #else
 	err = netgen::OCCGenerateMesh(occgeo, mesh_ptr, netgen::mparam, startWith, endWith);
 #endif
-#elif NETGEN_VERSION >= NETGEN_VERSION_STRING(5,0)
+#elif NETGEN_VERSION >= NETGEN_VERSION_STRING(5,0,0)
 	ngMesh->CalcLocalH(netgen::mparam.grading);
 	err = netgen::OCCGenerateMesh(occgeo, ngMesh, netgen::mparam, startWith, endWith);
 #else
@@ -625,7 +625,7 @@ bool NETGENPlugin_NETGEN_3D::Compute(SMESH_Mesh&         aMesh,
   int Netgen_triangle[3];
 
   NETGENPlugin_NetgenLibWrapper ngLib;
-#if NETGEN_VERSION < NETGEN_VERSION_STRING(6,0)
+#if NETGEN_VERSION < NETGEN_VERSION_STRING(6,0,0)
   Ng_Mesh * Netgen_mesh = ngLib._ngMesh;
 #else
   Ng_Mesh * Netgen_mesh = ngLib._ngMesh.get();


### PR DESCRIPTION
This PR is mainly a replacement for @looooo 's #21. As you have discussed in that PR the netgen devs have extended the NetgenConfig.cmake file by adding several variables. Mainly the new NETGEN_VERSION_PATCH is very useful as it's now possible to distinguish between different 6.2.x netgen versions.

This solves many open issues of #21:
* NEW_NETGEN_INTERFACE is not needed any more because with the patch number everything is done "automagically".
* It was mentioned that smesh has problems with C++17 (is the set_unexpected issue related to it?). In this PR C++17 is not set for the whole project but only for the NetgenPlugin target
* In the FreeCAD forum looooo said that his smesh/netgen 6.2 crashes on Windows. On my Windows system I got it working but needed a workaround -- see below for more details.

Open issues:
The version number is encoded by shifting the major version by 16 bits, the minor version by 8 bits and the patch number by 0 bits. So, the patch number has 8 bits available but the highest number that can be represented is 255. Since the real patch number is something like 1808, 2004, 2006, ... this causes an ambiguity.
E.g. when encoding 6.2.2004 we end up with the same number as the possible version 6.9.212
A solution will be to shift the minor number by 12 instead of 8 bits. But at the moment this is only a theoretical issue.

As mentioned above I needed a workaround to avoid a crash when the "optimize" option of the NETGENPlugin_Hypothesis is on. For the meshing this sets the perfstepsend value to MESHCONST_OPTSURFACE but somehow netgen doesn't like it and causes a segmentation fault. So, the workaround is to check this beforehand and set the value to MESHCONST_MESHSURFACE.
Since the function OCCGenerateMesh() has been removed from netgen it's a bit difficult to achieve the same behaviour with the new API. If I find a proper solution I will create a new PR. So, this PR can be already merged (if OK).