### PR TITLE
add Boost_INCLUDE_DIRS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ find_package(VTK REQUIRED COMPONENTS CommonCore CommonDataModel FiltersVerdict)
 # --------------------------------------------------------------------------- #
 message(STATUS "Searching for Boost...")
 find_package(Boost REQUIRED COMPONENTS filesystem thread serialization)
+inclue_directories(${Boost_INCLUDE_DIRS})
 
 if (MSVC)
   # find the shared boost libs


### PR DESCRIPTION
osx is failing because boost headers are not found. Normally headers in $Prefix/include are automatically found. Somehow they are not for osx right now. Might be a conda issue. But I guess manually including them will also resolve the issue.